### PR TITLE
Fix: 포켓몬 카드 타이틀 hover 액션 제거

### DIFF
--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -24,9 +24,7 @@ export default function PokemonCard({ pokemon }: PokemonCardProps) {
         height={90}
       />
 
-      <span className="text-lg font-medium hover:underline hover:font-semibold">
-        {pokemon.name}
-      </span>
+      <span className="text-lg font-medium">{pokemon.name}</span>
 
       <div className="w-full absolute bottom-0">
         <div className="h-2 bg-black" />


### PR DESCRIPTION
## 🚀 PR 요약

> 포켓몬 카드 타이틀 hocer 액션 제거

## ✏️ 변경 유형

- fix: 버그 수정


## 🗒️ 상세 내용 (선택)

### 작업 사항

- 포켓몬 카드 타이틀 hover 액션 제거

### 참고 사항

- ㅇㅇㅇ은 다음 작업에서 추가 예정

### 스크린 샷

> 화면을 새로 추가했거나 이전과 변화가 있을 경우 추가

## 🔗 연관된 이슈

> closes #34
